### PR TITLE
chore: remove unused categorizeDependency method from GenericAnalyzer

### DIFF
--- a/src/analyzers/generic/index.ts
+++ b/src/analyzers/generic/index.ts
@@ -397,20 +397,6 @@ export class GenericAnalyzer implements FrameworkAnalyzer {
     return components;
   }
 
-  private categorizeDependency(name: string): any {
-    // Basic categorization
-    if (name.includes('test') || name.includes('jest') || name.includes('vitest')) {
-      return 'testing';
-    }
-    if (name.includes('eslint') || name.includes('prettier') || name.includes('lint')) {
-      return 'build';
-    }
-    if (name.startsWith('@types/')) {
-      return 'build';
-    }
-    return 'other';
-  }
-
   /**
    * Generate generic summary for any code chunk
    */


### PR DESCRIPTION
## Summary
Removes the unused private method `categorizeDependency` from `GenericAnalyzer`. 

## Details
The class imports `categorizeDependency` from `../../utils/dependency-detection.js` and uses that imported function. The private method `this.categorizeDependency` was dead code.

## Checks
- [x] Linting passed
- [x] Build passed
- [x] Tests passed