### PR TITLE
fix: make exclude patterns recursive to prevent index pollution

### DIFF
--- a/src/constants/codebase-context.ts
+++ b/src/constants/codebase-context.ts
@@ -25,3 +25,36 @@ export const INDEXING_STATS_FILENAME = 'indexing-stats.json' as const;
 export const VECTOR_DB_DIRNAME = 'index' as const;
 export const MANIFEST_FILENAME = 'manifest.json' as const;
 export const RELATIONSHIPS_FILENAME = 'relationships.json' as const;
+
+/**
+ * Directories excluded from indexing, file-watching, and project discovery.
+ * Single source of truth — all three consumers import from here.
+ */
+export const EXCLUDED_DIRECTORY_NAMES = [
+  '.cache',
+  '.claude',
+  '.codebase-context',
+  '.git',
+  '.next',
+  '.nx',
+  '.planning',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'target',
+  'vendor',
+  'worktrees'
+] as const;
+
+/** Glob patterns that match excluded directories at any nesting depth. */
+export const EXCLUDED_GLOB_PATTERNS: string[] = EXCLUDED_DIRECTORY_NAMES.map(
+  (dir) => `**/${dir}/**`
+);
+
+/**
+ * Additional directories skipped only during project discovery (not generated
+ * code, just not useful roots to recurse into).
+ */
+export const DISCOVERY_ONLY_IGNORED = ['.hg', '.nuxt', '.svn', '.venv', '.yarn', 'out', 'tmp'] as const;

--- a/src/constants/codebase-context.ts
+++ b/src/constants/codebase-context.ts
@@ -57,4 +57,12 @@ export const EXCLUDED_GLOB_PATTERNS: string[] = EXCLUDED_DIRECTORY_NAMES.map(
  * Additional directories skipped only during project discovery (not generated
  * code, just not useful roots to recurse into).
  */
-export const DISCOVERY_ONLY_IGNORED = ['.hg', '.nuxt', '.svn', '.venv', '.yarn', 'out', 'tmp'] as const;
+export const DISCOVERY_ONLY_IGNORED = [
+  '.hg',
+  '.nuxt',
+  '.svn',
+  '.venv',
+  '.yarn',
+  'out',
+  'tmp'
+] as const;

--- a/src/constants/codebase-context.ts
+++ b/src/constants/codebase-context.ts
@@ -49,7 +49,7 @@ export const EXCLUDED_DIRECTORY_NAMES = [
 ] as const;
 
 /** Glob patterns that match excluded directories at any nesting depth. */
-export const EXCLUDED_GLOB_PATTERNS: string[] = EXCLUDED_DIRECTORY_NAMES.map(
+export const EXCLUDED_GLOB_PATTERNS: readonly string[] = EXCLUDED_DIRECTORY_NAMES.map(
   (dir) => `**/${dir}/**`
 );
 

--- a/src/core/file-watcher.ts
+++ b/src/core/file-watcher.ts
@@ -1,5 +1,6 @@
 import chokidar from 'chokidar';
 import path from 'path';
+import { EXCLUDED_GLOB_PATTERNS } from '../constants/codebase-context.js';
 import { getSupportedExtensions } from '../utils/language-detection.js';
 
 export interface FileWatcherOptions {
@@ -43,18 +44,7 @@ export function startFileWatcher(opts: FileWatcherOptions): () => void {
   };
 
   const watcher = chokidar.watch(rootPath, {
-    ignored: [
-      '**/node_modules/**',
-      '**/.codebase-context/**',
-      '**/.git/**',
-      '**/dist/**',
-      '**/.nx/**',
-      '**/.planning/**',
-      '**/coverage/**',
-      '**/.turbo/**',
-      '**/.next/**',
-      '**/.cache/**'
-    ],
+    ignored: [...EXCLUDED_GLOB_PATTERNS],
     persistent: true,
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 100 }

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -39,6 +39,7 @@ import { mergeSmallChunks } from '../utils/chunking.js';
 import { getFileCommitDates } from '../utils/git-dates.js';
 import {
   CODEBASE_CONTEXT_DIRNAME,
+  EXCLUDED_GLOB_PATTERNS,
   INDEX_FORMAT_VERSION,
   INDEXING_STATS_FILENAME,
   INDEX_META_FILENAME,
@@ -274,14 +275,7 @@ export class CodebaseIndexer {
         '**/*.{sql,graphql,gql}',
         '**/*.{json,jsonc,yaml,yml,toml,xml}'
       ],
-      exclude: [
-        'node_modules/**',
-        'dist/**',
-        'build/**',
-        '.git/**',
-        'coverage/**',
-        '.codebase-context/**'
-      ],
+      exclude: [...EXCLUDED_GLOB_PATTERNS],
       respectGitignore: true,
       parsing: {
         maxFileSize: 1048576,

--- a/src/utils/project-discovery.ts
+++ b/src/utils/project-discovery.ts
@@ -1,10 +1,7 @@
 import { promises as fs } from 'fs';
 import type { Dirent } from 'fs';
 import path from 'path';
-import {
-  EXCLUDED_DIRECTORY_NAMES,
-  DISCOVERY_ONLY_IGNORED
-} from '../constants/codebase-context.js';
+import { EXCLUDED_DIRECTORY_NAMES, DISCOVERY_ONLY_IGNORED } from '../constants/codebase-context.js';
 
 export type ProjectEvidence =
   | 'existing_index'
@@ -23,10 +20,7 @@ export interface DiscoverProjectsOptions {
 
 const DEFAULT_MAX_DEPTH = 4;
 
-const IGNORED_DIRECTORY_NAMES = new Set([
-  ...EXCLUDED_DIRECTORY_NAMES,
-  ...DISCOVERY_ONLY_IGNORED
-]);
+const IGNORED_DIRECTORY_NAMES = new Set([...EXCLUDED_DIRECTORY_NAMES, ...DISCOVERY_ONLY_IGNORED]);
 
 const STRONG_DIRECTORY_MARKERS = new Set(['.codebase-context', '.git']);
 const WORKSPACE_MARKERS = new Set(['lerna.json', 'nx.json', 'pnpm-workspace.yaml', 'turbo.json']);

--- a/src/utils/project-discovery.ts
+++ b/src/utils/project-discovery.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from 'fs';
 import type { Dirent } from 'fs';
 import path from 'path';
+import {
+  EXCLUDED_DIRECTORY_NAMES,
+  DISCOVERY_ONLY_IGNORED
+} from '../constants/codebase-context.js';
 
 export type ProjectEvidence =
   | 'existing_index'
@@ -20,22 +24,8 @@ export interface DiscoverProjectsOptions {
 const DEFAULT_MAX_DEPTH = 4;
 
 const IGNORED_DIRECTORY_NAMES = new Set([
-  '.git',
-  '.hg',
-  '.svn',
-  '.next',
-  '.nuxt',
-  '.turbo',
-  '.venv',
-  '.yarn',
-  'build',
-  'coverage',
-  'dist',
-  'node_modules',
-  'out',
-  'target',
-  'tmp',
-  'vendor'
+  ...EXCLUDED_DIRECTORY_NAMES,
+  ...DISCOVERY_ONLY_IGNORED
 ]);
 
 const STRONG_DIRECTORY_MARKERS = new Set(['.codebase-context', '.git']);

--- a/src/utils/project-discovery.ts
+++ b/src/utils/project-discovery.ts
@@ -20,7 +20,10 @@ export interface DiscoverProjectsOptions {
 
 const DEFAULT_MAX_DEPTH = 4;
 
-const IGNORED_DIRECTORY_NAMES = new Set([...EXCLUDED_DIRECTORY_NAMES, ...DISCOVERY_ONLY_IGNORED]);
+const IGNORED_DIRECTORY_NAMES: Set<string> = new Set([
+  ...EXCLUDED_DIRECTORY_NAMES,
+  ...DISCOVERY_ONLY_IGNORED
+]);
 
 const STRONG_DIRECTORY_MARKERS = new Set(['.codebase-context', '.git']);
 const WORKSPACE_MARKERS = new Set(['lerna.json', 'nx.json', 'pnpm-workspace.yaml', 'turbo.json']);

--- a/tests/indexer-exclude-patterns.test.ts
+++ b/tests/indexer-exclude-patterns.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { CodebaseIndexer } from '../src/core/indexer.js';
+import { analyzerRegistry } from '../src/core/analyzer-registry.js';
+import { GenericAnalyzer } from '../src/analyzers/generic/index.js';
+import {
+  CODEBASE_CONTEXT_DIRNAME,
+  KEYWORD_INDEX_FILENAME
+} from '../src/constants/codebase-context.js';
+
+describe('Indexer exclude patterns — nested directories', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    analyzerRegistry.register(new GenericAnalyzer());
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'indexer-exclude-patterns-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('excludes nested coverage, worktrees, .claude, and dist directories', async () => {
+    // Legitimate source file
+    await fs.mkdir(path.join(tempDir, 'src'), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, 'src', 'app.ts'),
+      'export function main() { return "hello"; }\n'
+    );
+
+    // Polluters — nested paths that should be excluded
+    const polluters = [
+      ['packages', 'ui', 'coverage', 'prettify.js'],
+      ['.claude', 'worktrees', 'branch', 'src', 'app.ts'],
+      ['worktrees', 'portal30-pr', 'src', 'real.ts'],
+      ['apps', 'web', 'dist', 'bundle.js']
+    ];
+
+    for (const segments of polluters) {
+      const dir = path.join(tempDir, ...segments.slice(0, -1));
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, ...segments),
+        'export const polluter = true;\n'
+      );
+    }
+
+    const indexer = new CodebaseIndexer({
+      rootPath: tempDir,
+      config: {
+        skipEmbedding: true,
+        parsing: {
+          maxFileSize: 1048576,
+          chunkSize: 50,
+          chunkOverlap: 0,
+          parseTests: true,
+          parseNodeModules: false
+        }
+      }
+    });
+
+    await indexer.index();
+
+    const indexPath = path.join(tempDir, CODEBASE_CONTEXT_DIRNAME, KEYWORD_INDEX_FILENAME);
+    const indexRaw = JSON.parse(await fs.readFile(indexPath, 'utf-8')) as Record<string, unknown>;
+    const chunks = (
+      Array.isArray(indexRaw)
+        ? indexRaw
+        : Array.isArray(indexRaw?.chunks)
+          ? indexRaw.chunks
+          : []
+    ) as Array<{ filePath: string }>;
+    const indexedPaths = chunks.map((chunk) => chunk.filePath);
+
+    // The legitimate file must be indexed
+    expect(indexedPaths.some((p) => p.includes('src/app.ts') || p.includes('src\\app.ts'))).toBe(
+      true
+    );
+
+    // None of the polluter paths should appear
+    const polluterMarkers = ['coverage', '.claude', 'worktrees', 'dist'];
+    for (const marker of polluterMarkers) {
+      const leaked = indexedPaths.filter((p) => p.includes(marker));
+      expect(leaked, `paths containing "${marker}" should not be indexed`).toEqual([]);
+    }
+  });
+});

--- a/tests/indexer-exclude-patterns.test.ts
+++ b/tests/indexer-exclude-patterns.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -13,16 +13,14 @@ import {
 describe('Indexer exclude patterns — nested directories', () => {
   let tempDir: string;
 
-  beforeEach(async () => {
-    analyzerRegistry.register(new GenericAnalyzer());
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'indexer-exclude-patterns-'));
-  });
-
   afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true });
+    if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   it('excludes nested coverage, worktrees, .claude, and dist directories', async () => {
+    analyzerRegistry.register(new GenericAnalyzer());
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'indexer-exclude-patterns-'));
+
     // Legitimate source file
     await fs.mkdir(path.join(tempDir, 'src'), { recursive: true });
     await fs.writeFile(
@@ -41,10 +39,7 @@ describe('Indexer exclude patterns — nested directories', () => {
     for (const segments of polluters) {
       const dir = path.join(tempDir, ...segments.slice(0, -1));
       await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(
-        path.join(tempDir, ...segments),
-        'export const polluter = true;\n'
-      );
+      await fs.writeFile(path.join(tempDir, ...segments), 'export const polluter = true;\n');
     }
 
     const indexer = new CodebaseIndexer({
@@ -65,13 +60,18 @@ describe('Indexer exclude patterns — nested directories', () => {
 
     const indexPath = path.join(tempDir, CODEBASE_CONTEXT_DIRNAME, KEYWORD_INDEX_FILENAME);
     const indexRaw = JSON.parse(await fs.readFile(indexPath, 'utf-8')) as Record<string, unknown>;
-    const chunks = (
-      Array.isArray(indexRaw)
-        ? indexRaw
-        : Array.isArray(indexRaw?.chunks)
-          ? indexRaw.chunks
-          : []
-    ) as Array<{ filePath: string }>;
+
+    let chunks: Array<{ filePath: string }>;
+    if (Array.isArray(indexRaw)) {
+      chunks = indexRaw;
+    } else if (Array.isArray(indexRaw?.chunks)) {
+      chunks = indexRaw.chunks as Array<{ filePath: string }>;
+    } else {
+      throw new Error(
+        `Unexpected index format: keys=${JSON.stringify(Object.keys(indexRaw ?? {}))}`
+      );
+    }
+
     const indexedPaths = chunks.map((chunk) => chunk.filePath);
 
     // The legitimate file must be indexed


### PR DESCRIPTION
## Summary

- **Extract shared `EXCLUDED_DIRECTORY_NAMES` and `EXCLUDED_GLOB_PATTERNS`** into `src/constants/codebase-context.ts` — single source of truth for the indexer, file-watcher, and project-discovery
- **Make all exclude globs recursive** (`**/coverage/**` instead of `coverage/**`) so nested occurrences in monorepo packages and worktrees are caught
- **Add missing directories**: `.cache`, `.claude`, `.planning`, `worktrees`, `target`, `vendor`, `.nx`, `.turbo`, `.next`, `build`

Fixes the two high-severity findings from the consumer audit (2026-03-17, <redacted>):
1. Worktrees/`.claude` directories leaking into the index
2. Nested generated artifacts (`packages/ui/coverage/prettify.js`) indexed as real code

This is the only unique delta from the closed PR #75 (commit d1197a9).

## Test plan

- [x] New integration test (`tests/indexer-exclude-patterns.test.ts`) reproduces the exact audit failure case — nested `coverage/`, `.claude/worktrees/`, `worktrees/`, and `dist/` directories
- [x] Full suite passes (312/312)
- [x] ESLint + Prettier clean on all changed files