### PR TITLE
test: stabilize follow-up integration suites

### DIFF
--- a/tests/impact-2hop.test.ts
+++ b/tests/impact-2hop.test.ts
@@ -17,7 +17,8 @@ import {
 
 vi.mock('../src/core/reranker.js', () => ({
   rerank: vi.fn(async (_query: string, results: unknown) => results),
-  getRerankerStatus: vi.fn(() => 'fallback')
+  getRerankerStatus: vi.fn(() => 'fallback'),
+  isAmbiguous: vi.fn(() => false)
 }));
 
 describe('Impact candidates (2-hop)', () => {

--- a/tests/impact-2hop.test.ts
+++ b/tests/impact-2hop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -14,6 +14,11 @@ import {
   MEMORY_FILENAME,
   RELATIONSHIPS_FILENAME
 } from '../src/constants/codebase-context.js';
+
+vi.mock('../src/core/reranker.js', () => ({
+  rerank: vi.fn(async (_query: string, results: unknown) => results),
+  getRerankerStatus: vi.fn(() => 'fallback')
+}));
 
 describe('Impact candidates (2-hop)', () => {
   let tempRoot: string | null = null;

--- a/tests/index-migration-atomic-swap.test.ts
+++ b/tests/index-migration-atomic-swap.test.ts
@@ -214,7 +214,7 @@ export function greet(user: User): string {
     // Verify staging directory is cleaned up
     const hasStaging = await stagingDirExists(contextDir);
     expect(hasStaging).toBe(false);
-  });
+  }, 30000);
 
   it('should fail closed when meta points to missing artifacts', async () => {
     // Create an index with meta pointing to non-existent files

--- a/tests/search-decision-card.test.ts
+++ b/tests/search-decision-card.test.ts
@@ -207,7 +207,7 @@ export class ProfileService {
     }
     expect(preflight.ready).toBeDefined();
     expect(typeof preflight.ready).toBe('boolean');
-  });
+  }, 30000);
 
   it('decision card has all expected fields when returned', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');
@@ -259,7 +259,7 @@ export class ProfileService {
     if (preflight.whatWouldHelp) {
       expect(Array.isArray(preflight.whatWouldHelp)).toBe(true);
     }
-  });
+  }, 30000);
 
   it('intent="explore" returns lightweight preflight', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');
@@ -290,7 +290,7 @@ export class ProfileService {
       expect(typeof preflight.ready).toBe('boolean');
       // Should NOT have full decision card fields for explore
     }
-  });
+  }, 30000);
 
   it('includes snippet field when includeSnippets=true', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');
@@ -321,7 +321,7 @@ export class ProfileService {
     // At least some results should have a snippet
     const withSnippets = parsed.results.filter((result) => result.snippet);
     expect(withSnippets.length).toBeGreaterThan(0);
-  });
+  }, 30000);
 
   it('does not include snippet field when includeSnippets=false', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');
@@ -350,7 +350,7 @@ export class ProfileService {
     parsed.results.forEach((result) => {
       expect(result.snippet).toBeUndefined();
     });
-  });
+  }, 30000);
 
   it('scope header starts snippet when includeSnippets=true', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');
@@ -381,5 +381,5 @@ export class ProfileService {
       const firstLine = withSnippet.snippet.split('\n')[0].trim();
       expect(firstLine).toMatch(/^\/\//);
     }
-  });
+  }, 30000);
 });

--- a/tests/search-decision-card.test.ts
+++ b/tests/search-decision-card.test.ts
@@ -5,6 +5,11 @@ import path from 'path';
 import { CodebaseIndexer } from '../src/core/indexer.js';
 import { rmWithRetries } from './test-helpers.js';
 
+vi.mock('../src/core/reranker.js', () => ({
+  rerank: vi.fn(async (_query: string, results: unknown) => results),
+  getRerankerStatus: vi.fn(() => 'fallback')
+}));
+
 type ToolCallRequest = {
   jsonrpc: '2.0';
   id: number;

--- a/tests/search-decision-card.test.ts
+++ b/tests/search-decision-card.test.ts
@@ -7,7 +7,8 @@ import { rmWithRetries } from './test-helpers.js';
 
 vi.mock('../src/core/reranker.js', () => ({
   rerank: vi.fn(async (_query: string, results: unknown) => results),
-  getRerankerStatus: vi.fn(() => 'fallback')
+  getRerankerStatus: vi.fn(() => 'fallback'),
+  isAmbiguous: vi.fn(() => false)
 }));
 
 type ToolCallRequest = {

--- a/tests/search-hints.test.ts
+++ b/tests/search-hints.test.ts
@@ -145,7 +145,7 @@ describe('Search Hints', () => {
       // Should be capped at 3
       expect(utilResult.hints.callers.length).toBeLessThanOrEqual(3);
     }
-  });
+  }, 30000);
 
   it('hints include tests when test files are detected', async () => {
     if (!tempRoot) throw new Error('tempRoot not initialized');

--- a/tests/search-hints.test.ts
+++ b/tests/search-hints.test.ts
@@ -11,6 +11,12 @@ import {
   KEYWORD_INDEX_FILENAME
 } from '../src/constants/codebase-context.js';
 
+vi.mock('../src/core/reranker.js', () => ({
+  rerank: vi.fn(async (_query: string, results: unknown) => results),
+  getRerankerStatus: vi.fn(() => 'fallback'),
+  isAmbiguous: vi.fn(() => false)
+}));
+
 describe('Search Hints', () => {
   let tempRoot: string | null = null;
 

--- a/tests/search-snippets.test.ts
+++ b/tests/search-snippets.test.ts
@@ -7,7 +7,8 @@ import { rmWithRetries } from './test-helpers.js';
 
 vi.mock('../src/core/reranker.js', () => ({
   rerank: vi.fn(async (_query: string, results: unknown) => results),
-  getRerankerStatus: vi.fn(() => 'fallback')
+  getRerankerStatus: vi.fn(() => 'fallback'),
+  isAmbiguous: vi.fn(() => false)
 }));
 
 describe('Search Snippets with Scope Headers', () => {

--- a/tests/search-snippets.test.ts
+++ b/tests/search-snippets.test.ts
@@ -5,6 +5,11 @@ import path from 'path';
 import { CodebaseIndexer } from '../src/core/indexer.js';
 import { rmWithRetries } from './test-helpers.js';
 
+vi.mock('../src/core/reranker.js', () => ({
+  rerank: vi.fn(async (_query: string, results: unknown) => results),
+  getRerankerStatus: vi.fn(() => 'fallback')
+}));
+
 describe('Search Snippets with Scope Headers', () => {
   let tempRoot: string | null = null;
 

--- a/tests/zombie-guard.test.ts
+++ b/tests/zombie-guard.test.ts
@@ -117,6 +117,6 @@ describe('zombie process prevention', () => {
     expect(result.code).toBe(1);
     // Should still honor a short timeout (allow CI/Windows process jitter).
     expect(elapsed).toBeGreaterThan(800);
-    expect(elapsed).toBeLessThan(7_000);
-  }, 10_000);
+    expect(elapsed).toBeLessThan(8_000);
+  }, 12_000);
 });


### PR DESCRIPTION
## Summary
- stabilize the release follow-up integration tests by mocking the reranker in search-heavy suites that should stay keyword/index focused
- relax timeout bounds for the Windows-sensitive integration cases that were failing under suite contention
- keep this PR strictly version-neutral so Release Please remains the release path instead of this branch

## Scope
This PR intentionally excludes the manual release prep that had been sitting on elease/v2.1.0-publish.

Included:
- 	ests/impact-2hop.test.ts
- 	ests/search-decision-card.test.ts
- 	ests/search-snippets.test.ts
- 	ests/index-migration-atomic-swap.test.ts
- 	ests/zombie-guard.test.ts
- 	ests/search-hints.test.ts

Excluded on purpose:
- package.json version bumps
- release-surface doc edits
- Release Please / publish changes

## Verification
- pnpm run type-check
- pnpm test
- additional focused reruns:
  - pnpm test -- tests/zombie-guard.test.ts
  - pnpm test -- tests/search-hints.test.ts

## Release Note
There is already an open Release Please PR for 1.10.0 (#79). This branch is only the cleanup follow-up needed to land the test stabilization work on master; the actual release/version decision should continue through the release automation path.