### PR TITLE
test(map): track symbol-aware fixture index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .codebase-context/*
 **/.codebase-context/*
 !/.codebase-context/memory.json
+!tests/fixtures/map-fixture/.codebase-context/index.json
 .codebase/
 *.log
 .DS_Store

--- a/tests/fixtures/map-fixture/.codebase-context/index.json
+++ b/tests/fixtures/map-fixture/.codebase-context/index.json
@@ -1,0 +1,76 @@
+{
+  "header": { "buildId": "test-build-13", "formatVersion": 4 },
+  "chunks": [
+    {
+      "id": "c1",
+      "content": "export interface SearchOptions {\n  query: string;\n  limit?: number;\n}",
+      "filePath": "/fixture/src/core/search.ts",
+      "relativePath": "src/core/search.ts",
+      "startLine": 1,
+      "endLine": 4,
+      "language": "typescript",
+      "dependencies": [],
+      "imports": [],
+      "exports": ["SearchOptions"],
+      "tags": [],
+      "metadata": {
+        "symbolAware": true,
+        "symbolName": "SearchOptions",
+        "symbolKind": "interface"
+      }
+    },
+    {
+      "id": "c2",
+      "content": "export class CodebaseSearcher {\n  private rootPath: string;\n  constructor(rootPath: string) {\n    this.rootPath = rootPath;\n  }\n}",
+      "filePath": "/fixture/src/core/search.ts",
+      "relativePath": "src/core/search.ts",
+      "startLine": 10,
+      "endLine": 20,
+      "language": "typescript",
+      "dependencies": [],
+      "imports": [],
+      "exports": ["CodebaseSearcher"],
+      "tags": [],
+      "metadata": {
+        "symbolAware": true,
+        "symbolName": "CodebaseSearcher",
+        "symbolKind": "class"
+      }
+    },
+    {
+      "id": "c3",
+      "content": "export type SearchResult = { chunk: CodeChunk; score: number; };",
+      "filePath": "/fixture/src/types.ts",
+      "relativePath": "src/types.ts",
+      "startLine": 5,
+      "endLine": 5,
+      "language": "typescript",
+      "dependencies": [],
+      "imports": [],
+      "exports": ["SearchResult"],
+      "tags": [],
+      "metadata": {
+        "symbolAware": true,
+        "symbolName": "SearchResult",
+        "symbolKind": "type"
+      }
+    },
+    {
+      "id": "c4",
+      "content": "function helperUtil() {\n  return 42;\n}",
+      "filePath": "/fixture/src/utils/helpers.ts",
+      "relativePath": "src/utils/helpers.ts",
+      "startLine": 1,
+      "endLine": 3,
+      "language": "typescript",
+      "dependencies": [],
+      "imports": [],
+      "exports": [],
+      "tags": [],
+      "metadata": {
+        "symbolAware": false,
+        "symbolKind": "function"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/map-fixture/.codebase-context/index.json
+++ b/tests/fixtures/map-fixture/.codebase-context/index.json
@@ -1,5 +1,5 @@
 {
-  "header": { "buildId": "test-build-13", "formatVersion": 4 },
+  "header": { "buildId": "map-fixture-v1", "formatVersion": 4 },
   "chunks": [
     {
       "id": "c1",
@@ -25,7 +25,7 @@
       "filePath": "/fixture/src/core/search.ts",
       "relativePath": "src/core/search.ts",
       "startLine": 10,
-      "endLine": 20,
+      "endLine": 15,
       "language": "typescript",
       "dependencies": [],
       "imports": [],


### PR DESCRIPTION
## Summary
This restores the tracked fixture data that `tests/codebase-map.test.ts` expects for symbol-aware `keyInterfaces` coverage.

## What changed
- add `tests/fixtures/map-fixture/.codebase-context/index.json`
- add a narrow `.gitignore` exception so this fixture artifact stays tracked in Git

## Why
`origin/master` was red because the fixture index was only present locally and ignored by Git, so CI never saw the symbol-aware chunks that back the `keyInterfaces` assertions and markdown snapshot.

## Verification
- `pnpm test -- tests/codebase-map.test.ts`
- `pnpm run type-check`

The full local suite on this worktree still shows unrelated baseline timeouts/build prerequisites outside this fix; this PR is intentionally limited to the concrete GitHub failure it repairs.