### PR TITLE
fix(ci): build before release tests

### DIFF
--- a/.github/workflows/publish-npm-on-release.yml
+++ b/.github/workflows/publish-npm-on-release.yml
@@ -53,8 +53,8 @@ jobs:
           pnpm lint
           pnpm format:check
           pnpm type-check
-          pnpm test
           pnpm build
+          pnpm test
 
       - name: Publish to npm with provenance
         if: steps.check.outputs.already_published != 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,8 +57,8 @@ jobs:
           pnpm lint
           pnpm format:check
           pnpm type-check
-          pnpm test
           pnpm build
+          pnpm test
 
       - name: Publish to npm with provenance
         if: ${{ steps.release.outputs.release_created && env.SKIP_PUBLISH != 'true' }}


### PR DESCRIPTION
## Summary
- build before test in the release-please publish job
- build before test in the manual publish-on-release fallback job
- preserve the same release-only quality gates while fixing the zombie-guard dist artifact failure

## Verification
- pnpm build
- pnpm test -- tests/zombie-guard.test.ts

Note: the clean recovery worktree did not have dependencies installed, so the verification above was run in the main repo worktree before the patch was moved onto the correct origin/master base.