### PR TITLE
fix(ci): allow manual release publish recovery

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,11 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to publish (e.g. v1.10.0)'
+        required: true
 
 permissions:
   contents: write
@@ -17,31 +22,51 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
+        if: ${{ github.event_name == 'push' }}
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Decide publish mode
+        id: mode
+        run: |
+          EVENT_NAME="${{ github.event_name }}"
+          MANUAL_TAG="${{ github.event.inputs.tag }}"
+          RELEASE_CREATED="${{ steps.release.outputs.release_created }}"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=$MANUAL_TAG" >> "$GITHUB_OUTPUT"
+          elif [ "$RELEASE_CREATED" = "true" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' }}
+        with:
+          ref: ${{ steps.mode.outputs.checkout_ref }}
 
       - uses: pnpm/action-setup@v2
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' }}
         with:
           version: 10
 
       - uses: actions/setup-node@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' }}
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
       - name: Install
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Check if version already published
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' }}
         run: |
           VERSION="$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")"
           if npm view "codebase-context@${VERSION}" version >/dev/null 2>&1; then
@@ -52,7 +77,7 @@ jobs:
           fi
 
       - name: Quality gates
-        if: ${{ steps.release.outputs.release_created && env.SKIP_PUBLISH != 'true' }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' && env.SKIP_PUBLISH != 'true' }}
         run: |
           pnpm lint
           pnpm format:check
@@ -61,5 +86,5 @@ jobs:
           pnpm test
 
       - name: Publish to npm with provenance
-        if: ${{ steps.release.outputs.release_created && env.SKIP_PUBLISH != 'true' }}
+        if: ${{ steps.mode.outputs.should_publish == 'true' && env.SKIP_PUBLISH != 'true' }}
         run: pnpm publish --access public --no-git-checks --provenance


### PR DESCRIPTION
## Summary
- add workflow_dispatch support to the trusted release-please workflow
- allow manual publish of an already-tagged release from the same workflow file npm trusts
- preserve the existing push-to-master release-please behavior

## Why
The fallback publish workflow can pass quality gates but still fail npm publish because the trusted publisher configuration is tied to elease-please.yml. This adds a safe recovery path for already-tagged releases like 1.10.0.

## Verification
- inspected the failed Release Please run for 1.10.0
- confirmed the fallback Publish to npm on release workflow fails with the same npm 404 permission pattern
- reviewed the resulting workflow diff to keep push behavior intact while adding manual recovery