### PR TITLE
chore(git): ignore local benchmark artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,26 @@ grammars/*.wasm
 docs/visuals.md
 .repolore/
 .opencode/
-.agents/
 CODEBASE_MAP.md
 repos/
+
+# Local benchmark/lab outputs
+benchmark-runs/
+outputs/
+results/skeptical-user/raw/
+results/skeptical-user/local/
+results/skeptical-user/tmp/
+.tmp-skeptical-user/
+
+# External benchmark/research clones
+matplotlib-repo/
+sympy-contextbench/
+
+# Local agent/vendor artifacts
+**/skills/bmad-*/
+_bmad/
+_bmad-*/
+_bmad-output/
+
+# Local browser automation artifacts
+.playwright-mcp/

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,10 @@ repos/
 
 # Local benchmark/lab outputs
 benchmark-runs/
-outputs/
-results/skeptical-user/raw/
-results/skeptical-user/local/
-results/skeptical-user/tmp/
+/outputs/
+/results/*/raw/
+/results/*/local/
+/results/*/tmp/
 .tmp-skeptical-user/
 
 # External benchmark/research clones
@@ -45,7 +45,6 @@ matplotlib-repo/
 sympy-contextbench/
 
 # Local agent/vendor artifacts
-**/skills/bmad-*/
 _bmad/
 _bmad-*/
 _bmad-output/


### PR DESCRIPTION
Keeps generated benchmark artifacts, external benchmark clones, local agent/vendor artifacts, and browser automation outputs out of future commits. No benchmark results are included or claimed.