### PR TITLE
test: keep scoped memory fixtures fresh

### DIFF
--- a/tests/search-health-scope.test.ts
+++ b/tests/search-health-scope.test.ts
@@ -28,6 +28,7 @@ describe('search_codebase health and scoped memories', () => {
   beforeEach(async () => {
     searchMocks.search.mockReset();
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'search-health-scope-'));
+    const currentDate = new Date().toISOString();
 
     const contextDir = path.join(tempRoot, '.codebase-context');
     await fs.mkdir(contextDir, { recursive: true });
@@ -56,7 +57,7 @@ describe('search_codebase health and scoped memories', () => {
             category: 'architecture',
             memory: 'Avoid direct token reads',
             reason: 'They bypass AuthService refresh logic.',
-            date: '2026-04-17T00:00:00.000Z',
+            date: currentDate,
             scope: {
               kind: 'symbol',
               file: 'src/auth/auth.service.ts',
@@ -69,7 +70,7 @@ describe('search_codebase health and scoped memories', () => {
             category: 'architecture',
             memory: 'Use auth interceptors',
             reason: 'They keep HTTP token injection consistent.',
-            date: '2026-04-17T00:00:00.000Z'
+            date: currentDate
           }
         ],
         null,

--- a/tests/search-scoped-memory.test.ts
+++ b/tests/search-scoped-memory.test.ts
@@ -28,6 +28,7 @@ describe('search_codebase scoped memories', () => {
   beforeEach(async () => {
     searchMocks.search.mockReset();
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'search-scoped-memory-'));
+    const currentDate = new Date().toISOString();
 
     const contextDir = path.join(tempRoot, '.codebase-context');
     await fs.mkdir(contextDir, { recursive: true });
@@ -55,7 +56,7 @@ describe('search_codebase scoped memories', () => {
             category: 'architecture',
             memory: 'Avoid direct token reads',
             reason: 'They bypass AuthService refresh logic.',
-            date: '2026-04-17T00:00:00.000Z',
+            date: currentDate,
             scope: {
               kind: 'symbol',
               file: 'src/auth/auth.service.ts',
@@ -68,7 +69,7 @@ describe('search_codebase scoped memories', () => {
             category: 'architecture',
             memory: 'Use auth interceptors',
             reason: 'They keep HTTP token injection consistent.',
-            date: '2026-04-17T00:00:00.000Z'
+            date: currentDate
           }
         ],
         null,


### PR DESCRIPTION
## Summary

Keep the scoped-memory test fixtures fresh so confidence decay does not filter the expected scoped memory before the ranking assertion runs.

## Root cause

The fixtures used a fixed April 2026 timestamp. As time passed, decay dropped the scoped memory below the compact-mode confidence threshold, causing two unrelated ranking tests to fail.

## Verification

- `pnpm run build`
- `pnpm test -- tests/search-health-scope.test.ts tests/search-scoped-memory.test.ts`
- `pnpm test` — 612 passed